### PR TITLE
Use setuptools_scm for auto-versioning from Git tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'isodate'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: deploy-${{ hashFiles('**/setup.py') }}
+          restore-keys: |
+            deploy-
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python -m build
+          twine check --strict dist/*
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__PYPI_API_TOKEN
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = isodate2
-version = 0.7.0
 description = An ISO 8601 date/time/duration parser and formatter
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -25,12 +24,16 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Internet
     Topic :: Software Development :: Libraries :: Python Modules
+project_urls =
+    Source=https://github.com/isodate/isodate
 
 [options]
 packages =
     isodate
 python_requires = >=3.6
 package_dir = =src
+setup_requires =
+    setuptools-scm
 
 [options.extras_require]
 tests =

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,12 @@
 from setuptools import setup
 
-setup()
+
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
+
+
+setup(
+    use_scm_version={"local_scheme": local_scheme},
+)


### PR DESCRIPTION
And deploy to Test PyPI for merges to master and to prod PyPI for tags. API tokens have been set up for https://github.com/pypa/gh-action-pypi-publish and stored as repo secrets.