### PR TITLE
Add __version__

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ project_urls =
 [options]
 packages =
     isodate
+install_requires =
+    importlib-metadata;python_version < '3.8'
 python_requires = >=3.6
 package_dir = =src
 setup_requires =

--- a/src/isodate/__init__.py
+++ b/src/isodate/__init__.py
@@ -124,3 +124,13 @@ __all__ = [
     "D_ALT_BAS_ORD",
     "D_ALT_EXT_ORD",
 ]
+
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # <Python 3.7 and lower
+    import importlib_metadata
+
+# Append "2" for isodate2
+__version__ = importlib_metadata.version(__name__ + "2")


### PR DESCRIPTION
Fixes https://github.com/gweis/isodate/issues/62.

We're using setuptools_scm, we can fetch the version number like this:

* https://github.com/pypa/setuptools_scm/#retrieving-package-version-at-runtime

# Before

```pycon
>>> import isodate
>>> isodate.__version__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'isodate' has no attribute '__version__'
```

# After

```pycon
>>> import isodate
>>> isodate.__version__
'0.7.1.dev28'
```

