### PR TITLE
Add LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,25 @@
+Copyright (c) 2021, Hugo van Kemenade and contributors Copyright (c) 2009-2018,
+Gerhard Weis and contributors Copyright 2009, Gerhard Weis All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name of the authors nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,7 @@
-Copyright (c) 2021, Hugo van Kemenade and contributors Copyright (c) 2009-2018,
-Gerhard Weis and contributors Copyright 2009, Gerhard Weis All rights reserved.
+Copyright (c) 2021, Hugo van Kemenade and contributors
+Copyright (c) 2009-2018, Gerhard Weis and contributors
+Copyright (c) 2009, Gerhard Weis
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ long_description_content_type = text/markdown
 url = https://github.com/isodate/isodate/
 author = Gerhard Weis
 author_email = gerhard.weis@proclos.com
-license = BSD
+license = BSD-3-Clause
+license_file = LICENSE.md
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers


### PR DESCRIPTION
This license file contains the same content as preamble found in the
source files, however it also includes the following part which is
missing from the end (after "... CONTRACT, STRICT LIABILITY, OR TORT"):

> (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
> OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

I'm somewhat of two minds if it is okay to include this additional part,
however I think it is given that the package uses "BSD" for the license
value in setuptools config and the
`License :: OSI Approved :: BSD License` classifier and most BSD licenses
end with same text after TORT, and this includes all BSD licenses on the
OSI site.

The license text itself is however not the same as the the 3-Clause BSD license
found at any of these locations:

- https://opensource.org/licenses/BSD-3-Clause
- https://spdx.org/licenses/BSD-3-Clause.html
- https://directory.fsf.org/wiki/License:BSD-3-Clause
  (differs from first two anyway)

The difference is mainly the first part of the third clause, which in the
isodate license is "Neither the name of the authors nor the names of its
contributors" instead of "Neither the name of the copyright holder nor the
names of its contributors may" (SDPX, OSI) and "The name of the author"
(FSF).

The most popular project with similar license text that I could find is
https://github.com/andialbrecht/sqlparse.

I formatted the file with:

```sh
npx prettier --prose-wrap always LICENSE.md
```