### PR TITLE
Fix deploy username

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         if: github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@master
         with:
-          user: __token__PYPI_API_TOKEN
+          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Publish package to TestPyPI


### PR DESCRIPTION
Copy/paste error causing 403 Forbidden.

https://github.com/isodate/isodate/runs/4127495913?check_suite_focus=true

Will redo the 0.8.0 tag/release.